### PR TITLE
投稿削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
-  before_action :set_item_params, only: [:show, :edit, :update]
-  before_action :anlyze_user, only: :edit
+  before_action :set_item_params, only: [:show, :edit, :update, :destroy]
+  before_action :anlyze_user, only: [:edit, :destroy]
 
   def index
     @items = Item.includes( :user ).order("created_at DESC")
@@ -33,6 +33,15 @@ class ItemsController < ApplicationController
       render :edit
     end
   end
+
+  def destroy
+      if @item.destroy
+        redirect_to root_path
+      else
+        redirect_to root_path
+      end
+  end
+
 
   private
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,6 +17,6 @@ class Item < ApplicationRecord
   validates :shipping_id, presence: true, numericality: { other_than: 1 , message: "can't be blank"}
   validates :prefecture_id, presence: true, numericality: { other_than: 1 , message: "can't be blank"}
   validates :until_shipping_id, presence: true, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :price, presence: true,format: { with: /\A[0-9]+\z/ }, numericality: {only_integer: true, greater_than: 300,less_than: 9999999}
+  validates :price, presence: true,format: { with: /\A[0-9]+\z/ }, numericality: {only_integer: true, greater_than: 299,less_than: 9999999}
 
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id%>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
   <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合表示 %>
 
       <% else %>


### PR DESCRIPTION
#What
商品削除機能の実装

#Why
商品削除機能を実装するため


 ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/d6ed5c540a63ced35377219abc94d0cc

#質問
ログイン状態の出品者のみ削除ができるという条件において、編集機能の際に作成した以下のメソッドを使い回しています。

```ruby
  before_action :anlyze_user, only: [:edit, :destroy]

# 中略

  def anlyze_user
    unless @item.user == current_user
      redirect_to root_path
    end
  end

```

条件式からこちらのメソッドが使えそうだと思ったのと、ログイン状態なら削除ができるという条件だけでは少し不十分な気がしていたのでこちらを使うことにしたのですが、何か不都合等発生しますでしょうか？
